### PR TITLE
feat: add flyway migrator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,15 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url= jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASS}
-spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=postgres
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# Prevent Hibernate from creating tables. The database is managed through the migration files.
+spring.jpa.hibernate.ddl-auto=none
+
+# Flyway
+spring.flyway.schemas=migrations
+spring.flyway.locations=classpath:db/migration
+# This option allows migration files to be modified in development.
+# This should be false in production.
+spring.flyway.cleanOnValidationError=${FLYWAY_DEV}

--- a/src/main/resources/db/migration/V001__Initial_schema.sql
+++ b/src/main/resources/db/migration/V001__Initial_schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS migrations; -- Create tables in this schema


### PR DESCRIPTION
This pr adds a flyway migrator to the project. The purpose is to be able to manage database changes in a consistent manner.

Note to all reviewer: once a migration file has been merged to main that file should not be modified anymore. Further db changes should be done in new migration files.

Closes #14 