### PR TITLE
feat: fix product image size

### DIFF
--- a/shopify-client/src/views/ProductDetails.vue
+++ b/shopify-client/src/views/ProductDetails.vue
@@ -12,7 +12,7 @@
           <b-col sm="6">
             <b-row>
               <b-col sm="12">
-                <b-img v-bind:src="product.image"></b-img>
+                <b-img v-bind:src="product.image" fluid></b-img>
               </b-col>
             </b-row>
           </b-col>


### PR DESCRIPTION
This PR makes sure the image on the product details page does not overflow indefinitely.