### PR TITLE
fix: Create Tag/Categories duplicate tags/categories

### DIFF
--- a/shopify-client/src/components/ShopForm.vue
+++ b/shopify-client/src/components/ShopForm.vue
@@ -324,10 +324,12 @@ export default {
 
     createTag() {
       let tagName = document.getElementById("createTagName").value;
-      if (tagName != undefined && tagName != '') {
+      if (tagName && !this.tags.find(t => t.name.localeCompare(tagName, undefined, { sensitivity: 'base' }))) {
         this.form.tags.push({ name: tagName });
 
         this.forceRender();
+      } else {
+        alert(`Invalid Tag Name - ${tagName ? 'Check if the tag already exists' : 'Please provide a tag name'}`);
       }
     },
 
@@ -352,10 +354,12 @@ export default {
 
     createCategory() {
       let categoryName = document.getElementById("createCategoryName").value;
-      if (categoryName) {
+      if (categoryName && !this.categories.find(c => c.name.localeCompare(categoryName, undefined, { sensitivity: 'base' }))) {
         this.form.categories.push({ name: categoryName });
 
         this.forceRender();
+      } else {
+        alert(`Invalid Category Name - ${categoryName ? 'Check if the category already exists' : 'Please provide a category name'}`);
       }
     },
 


### PR DESCRIPTION
This change checks if the tag or category exists already when trying to create a new category or tag. If not, an alert is displayed.

Closes Issue #83 